### PR TITLE
Adiciona model de promotion e relação com categoria

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,7 +1,8 @@
 class Category < ApplicationRecord
+  belongs_to :promotion, optional: true
+  belongs_to :admin
   belongs_to :category, class_name: 'Category', optional: true
   has_many :categories, class_name: 'Category', dependent: :destroy
-  belongs_to :admin
   has_many :products, dependent: :nullify
 
   enum status: { disabled: 0, active: 1 }

--- a/app/models/promotion.rb
+++ b/app/models/promotion.rb
@@ -2,15 +2,15 @@ class Promotion < ApplicationRecord
   has_many :categories
   belongs_to :admin
 
-  validates :start_date, :end_date, :name, :discount_max, :discount_percentual, :used_times, :coupon, :usage_limit, presence: true
+  validates :start_date, :end_date, :name, :discount_max, :discount_percentual, :used_times, :usage_limit, presence: true
   validates :usage_limit, :discount_max, :discount_percentual, numericality: { greater_than: 0 }
   validates :used_times, numericality: { greater_than_or_equal_to: 0 }
-  validates :coupon, length: { is: 8 }
+  validates :coupon, uniqueness: true
   validate :start_date_before_end_date
   validate :start_date_greater_than_today
   validate :usage_limit_is_greater_or_equal_to_used_times
 
-  before_create :generate_coupon
+  before_validation :generate_coupon, on: :create
 
   private
 

--- a/app/models/promotion.rb
+++ b/app/models/promotion.rb
@@ -1,0 +1,44 @@
+class Promotion < ApplicationRecord
+  has_many :categories
+  belongs_to :admin
+
+  validates :start_date, :end_date, :name, :discount_max, :discount_percentual, :used_times, :coupon, :usage_limit, presence: true
+  validates :usage_limit, :discount_max, :discount_percentual, numericality: { greater_than: 0 }
+  validates :used_times, numericality: { greater_than_or_equal_to: 0 }
+  validates :coupon, length: { is: 8 }
+  validate :start_date_before_end_date
+  validate :start_date_greater_than_today
+  validate :usage_limit_is_greater_or_equal_to_used_times
+
+  before_create :generate_coupon
+
+  private
+
+  def generate_coupon
+    self.coupon = SecureRandom.alphanumeric(8).upcase
+  end
+
+  def usage_limit_is_greater_or_equal_to_used_times
+    return unless usage_limit && used_times
+
+    return if usage_limit >= used_times
+
+    errors.add :used_times, message: 'não pode ser maior que o limite de usos'
+  end
+
+  def start_date_before_end_date
+    return unless start_date && end_date
+
+    return if start_date < end_date
+
+    errors.add :start_date, message: 'não pode ser maior que a data final'
+  end
+
+  def start_date_greater_than_today
+    return unless start_date
+
+    return if start_date >= Time.zone.today
+
+    errors.add :start_date, message: 'não pode ser anterior a hoje'
+  end
+end

--- a/db/migrate/20220621204509_create_promotions.rb
+++ b/db/migrate/20220621204509_create_promotions.rb
@@ -1,0 +1,17 @@
+class CreatePromotions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :promotions do |t|
+      t.date :start_date
+      t.date :end_date
+      t.string :name
+      t.integer :discount_percentual
+      t.decimal :discount_max
+      t.integer :used_times
+      t.string :coupon
+      t.integer :usage_limit
+      t.references :admin, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220621204831_add_promotion_to_category.rb
+++ b/db/migrate/20220621204831_add_promotion_to_category.rb
@@ -1,0 +1,5 @@
+class AddPromotionToCategory < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :categories, :promotion, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20220621214450_add_default_used_times_to_promotion.rb
+++ b/db/migrate/20220621214450_add_default_used_times_to_promotion.rb
@@ -1,0 +1,5 @@
+class AddDefaultUsedTimesToPromotion < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :promotions, :used_times, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_17_211620) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_21_214450) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_17_211620) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -60,9 +60,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_17_211620) do
     t.datetime "updated_at", null: false
     t.integer "admin_id", null: false
     t.integer "status", default: 1
+    t.integer "promotion_id"
     t.index ["admin_id"], name: "index_categories_on_admin_id"
     t.index ["category_id"], name: "index_categories_on_category_id"
     t.index ["name", "category_id"], name: "index_categories_on_name_and_category_id", unique: true
+    t.index ["promotion_id"], name: "index_categories_on_promotion_id"
   end
 
   create_table "clients", force: :cascade do |t|
@@ -120,13 +122,30 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_17_211620) do
     t.index ["sku"], name: "index_products_on_sku", unique: true
   end
 
+  create_table "promotions", force: :cascade do |t|
+    t.date "start_date"
+    t.date "end_date"
+    t.string "name"
+    t.integer "discount_percentual"
+    t.decimal "discount_max"
+    t.integer "used_times", default: 0
+    t.string "coupon"
+    t.integer "usage_limit"
+    t.integer "admin_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_id"], name: "index_promotions_on_admin_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "categories", "admins"
   add_foreign_key "categories", "categories"
+  add_foreign_key "categories", "promotions"
   add_foreign_key "prices", "admins"
   add_foreign_key "prices", "products"
   add_foreign_key "product_items", "clients"
   add_foreign_key "product_items", "products"
   add_foreign_key "products", "categories"
+  add_foreign_key "promotions", "admins"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,3 +52,12 @@ fourth_product.photos.attach(io: File.open(Rails.root.join('spec/support/files/p
                              filename: 'placeholder-image-2.png', content_type: 'image/png')
 Price.create!(admin: admin, product: fourth_product, start_date: Time.zone.today, end_date: 60.days.from_now,
               value: 140.00)
+
+first_promotion = Promotion.create!(name: 'BlackFriday', discount_percentual: 50, discount_max: 200, usage_limit: 100,
+                                    start_date: 1.day.from_now, end_date: 1.month.from_now, admin:)
+
+second_promotion = Promotion.create!(name: 'Dia das Mães', discount_percentual: 30, discount_max: 100, usage_limit: 50,
+                                    start_date: 1.day.from_now, end_date: 1.week.from_now, admin:)                                    
+
+third_promotion = Promotion.create!(name: 'Dia dos Namorados', discount_percentual: 20, discount_max: 60, usage_limit: 40,
+                                    start_date: 1.day.from_now, end_date: 1.week.from_now, admin:)                                                                        

--- a/spec/factories/promotions.rb
+++ b/spec/factories/promotions.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :promotion do
+    start_date { Time.zone.today }
+    end_date { 10.days.from_now }
+    name { "BlackFriday" }
+    discount_percentual { 40 }
+    discount_max { 100 }
+    used_times { 1 }
+    coupon { "ABCD1234" }
+    usage_limit { 10 }
+    association :admin
+  end
+end

--- a/spec/models/promotion_spec.rb
+++ b/spec/models/promotion_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe Promotion, type: :model do
+  describe '#valid' do
+    it { is_expected.to validate_presence_of(:start_date) }
+
+    it { is_expected.to validate_presence_of(:end_date) }
+
+    it { is_expected.to validate_presence_of(:name) }
+
+    it { is_expected.to validate_presence_of(:discount_max) }
+
+    it { is_expected.to validate_presence_of(:discount_percentual) }
+
+    it { is_expected.to validate_presence_of(:used_times) }
+
+    it { is_expected.to validate_presence_of(:coupon) }
+
+    it { is_expected.to validate_presence_of(:usage_limit) }
+
+    it { is_expected.to validate_length_of(:coupon).is_equal_to(8) }
+
+    it { is_expected.to validate_numericality_of(:discount_max).is_greater_than(0) }
+
+    it { is_expected.to validate_numericality_of(:discount_percentual).is_greater_than(0) }
+
+    it { is_expected.to validate_numericality_of(:usage_limit).is_greater_than(0) }
+    
+    it { is_expected.to validate_numericality_of(:used_times).is_greater_than_or_equal_to(0) }
+
+    it { is_expected.to belong_to(:admin) }
+
+    it 'true se limite de uso for maior ou igual a quantidade usada' do
+      promotion = described_class.new(usage_limit: 10, used_times: 10)
+
+      promotion.valid?
+
+      expect(promotion.errors.include?(:used_times)).to be false
+    end
+
+    it 'false se limite de uso for menor que quantidade usada' do
+      promotion = described_class.new(usage_limit: 10, used_times: 11)
+
+      promotion.valid?
+
+      expect(promotion.errors[:used_times]).to include 'não pode ser maior que o limite de usos'
+    end
+
+    it 'false se data inicial for maior que data final' do
+      promotion = described_class.new(start_date: 1.day.from_now, end_date: Time.zone.today)
+  
+      promotion.valid?
+  
+      expect(promotion.errors[:start_date]).to include 'não pode ser maior que a data final'
+    end
+  
+    it 'true se data inicial for menor que data final' do
+      promotion = described_class.new(start_date: Time.zone.today, end_date: 1.day.from_now)
+  
+      promotion.valid?
+  
+      expect(promotion.errors.include?(:start_date)).to be false
+    end
+  
+    it 'false se data inicial for anterior à data atual' do
+      promotion = described_class.new(start_date: 1.day.ago)
+  
+      promotion.valid?
+  
+      expect(promotion.errors[:start_date]).to include 'não pode ser anterior a hoje'
+    end
+  
+    it 'true se data inicial for igual ou posterior à data atual' do
+      promotion = described_class.new(start_date: Time.zone.today)
+  
+      promotion.valid?
+  
+      expect(promotion.errors.include?(:start_date)).to be false
+    end
+  end
+end

--- a/spec/models/promotion_spec.rb
+++ b/spec/models/promotion_spec.rb
@@ -14,11 +14,7 @@ RSpec.describe Promotion, type: :model do
 
     it { is_expected.to validate_presence_of(:used_times) }
 
-    it { is_expected.to validate_presence_of(:coupon) }
-
     it { is_expected.to validate_presence_of(:usage_limit) }
-
-    it { is_expected.to validate_length_of(:coupon).is_equal_to(8) }
 
     it { is_expected.to validate_numericality_of(:discount_max).is_greater_than(0) }
 
@@ -76,6 +72,36 @@ RSpec.describe Promotion, type: :model do
       promotion.valid?
   
       expect(promotion.errors.include?(:start_date)).to be false
+    end
+
+    it 'true se tamanho de coupon for igual a 8' do
+      promotion = described_class.new()
+
+      promotion.valid?
+
+      expect(promotion.coupon.length).to eq 8
+    end
+
+    it 'false se coupon já existir no banco de dados' do
+      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('ABCD1234')
+      create :promotion
+      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('ABCD1234')
+      promotion = described_class.new()
+
+      promotion.valid?
+      
+      expect(promotion.errors).to include :coupon
+    end
+
+    it 'true se coupon não existir no banco de dados' do
+      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('ABCD1234')
+      create :promotion
+      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('6789QWER')
+      promotion = described_class.new()
+
+      promotion.valid?
+      
+      expect(promotion.errors).not_to include :coupon
     end
   end
 end


### PR DESCRIPTION
#### Atende a issue #57 
Adiciona modelo de promoção com as associações necessárias e com as validações apropriadas para cada campo. Em código o modelo se chama **promotion** e possui os seguintes atributos:

- **start_date**: Data em que a promoção começa
- **end_date**: Data em que a promoção termina
- **name**: Nome/descrição da promoção
- **discount_percentual**: Percentual de desconto em cima do valor
- **discount_max**: Valor limite do desconto aplicado
- **used_times**: Quantidade de vezes que o desconto foi usado
- **usage_limit**: Limite de vezes que o desconto pode ser usado
- **coupon**: Código alfanumérico de 8 caracteres usado para identificação da promoção
- **admin_id**: Identificador da associação da promoção com o administrador que a criou

Além disso foi adicionada a relação entre categoria e promoção, adicionado o campo **promotion_id** a categoria.