### PR TITLE
Desativa produto expirado automáticamente

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,8 +3,10 @@ class ProductsController < ApplicationController
   before_action :authenticate_admin!, only: %i[new create activate deactivate]
 
   def index
-    @products = Product.all
     @categories = Category.active
+    Product.active.each do |product|
+      product.inactive! if product.prices.last.end_date < Time.zone.today
+    end
     @products = admin_signed_in? ? Product.all : Product.active
   end
 
@@ -34,7 +36,8 @@ class ProductsController < ApplicationController
   end
 
   def show
-    unless @product && (@product.active? || admin_signed_in?)
+    @product.inactive! if @product.prices.last.end_date < Time.zone.today
+    unless @product.active? || admin_signed_in?
       return redirect_to root_path, notice: t('inactive_or_inexistent_product')
     end
 
@@ -76,7 +79,7 @@ class ProductsController < ApplicationController
   def set_product
     @product = Product.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    @product = nil
+    redirect_to root_path, notice: t('inactive_or_inexistent_product')
   end
 
   def set_new_price

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_25_122545) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_27_123229) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -115,7 +115,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_25_122545) do
     t.integer "product_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "client_id", null: false
+    t.integer "client_id"
     t.integer "purchase_id"
     t.index ["client_id"], name: "index_product_items_on_client_id"
     t.index ["product_id"], name: "index_product_items_on_product_id"

--- a/spec/requests/visitor_tries_admin_actions_spec.rb
+++ b/spec/requests/visitor_tries_admin_actions_spec.rb
@@ -41,6 +41,7 @@ describe 'Visitante não autenticado' do
 
   it 'tenta visualizar produto inativo' do
     product = create :product, status: :inactive
+    create :price, product: product
 
     get product_path(product)
 

--- a/spec/system/admin/product/admin_views_product_details_spec.rb
+++ b/spec/system/admin/product/admin_views_product_details_spec.rb
@@ -63,4 +63,18 @@ describe 'Administrador acessa detalhes do produto' do
     expect(page).to have_current_path product_path(product)
     expect(page).to have_content('Inativo')
   end
+
+  it 'e vê um produto cujos preços expiraram como inativo' do
+    create :exchange_rate, value: 2.0
+    product = create :product, name: 'Monitor 8k', brand: 'LG'
+    create :price, product: product, value: 10.00, start_date: Time.zone.today, end_date: 45.days.from_now
+    create :price, product: product, value: 20.00, start_date: 46.days.from_now, end_date: 90.days.from_now
+    product.active!
+    allow(Time.zone).to receive(:today).and_return 91.days.from_now
+
+    login_as product.category.admin, scope: :admin
+    visit product_path(product)
+
+    expect(page).to have_content 'Inativo'
+  end
 end

--- a/spec/system/admin/product/admin_views_products_spec.rb
+++ b/spec/system/admin/product/admin_views_products_spec.rb
@@ -24,4 +24,20 @@ describe 'Administrador vê todos os produtos' do
       expect(page).to have_content 'Inativo'
     end
   end
+
+  it 'e vê um produto cujos preços expiraram como inativo' do
+    create :exchange_rate, value: 2.0
+    product = create :product, name: 'Monitor 8k', brand: 'LG'
+    create :price, product: product, value: 10.00, start_date: Time.zone.today, end_date: 45.days.from_now
+    create :price, product: product, value: 20.00, start_date: 46.days.from_now, end_date: 90.days.from_now
+    product.active!
+    allow(Time.zone).to receive(:today).and_return 91.days.from_now
+
+    login_as product.category.admin, scope: :admin
+    visit products_path
+
+    within("##{product.id}") do
+      expect(page).to have_content 'Inativo'
+    end
+  end
 end


### PR DESCRIPTION
## Desativar produto automáticamente #50 

Garante que produtos que foram criados corretamente porém deixaram de ter preços ativos são inativados automáticamente, quando alguém tenta visualiza-los.