### PR TITLE
Cria tela de exibição de cashbacks

### DIFF
--- a/app/controllers/cashbacks_controller.rb
+++ b/app/controllers/cashbacks_controller.rb
@@ -1,6 +1,10 @@
 class CashbacksController < ApplicationController
   before_action :authenticate_admin!
 
+  def index
+    @cashbacks = Cashback.all
+  end
+
   def new
     @cashback = Cashback.new
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,7 +9,7 @@ class ProductsController < ApplicationController
     end
     @products = admin_signed_in? ? Product.all : Product.active
   end
-  
+
   def new
     @product = Product.new
     @start_date = Time.zone.today
@@ -44,6 +44,7 @@ class ProductsController < ApplicationController
       return redirect_to root_path, notice: t('inactive_or_inexistent_product')
     end
 
+    set_cashback
     set_new_price
   end
 
@@ -77,13 +78,19 @@ class ProductsController < ApplicationController
     params.require(:product).permit(:name, :brand, :category_id, :description, :sku, :width, :height,
                                     :depth, :weight, :shipping_price, :fragile, :manual, :cashback_id,
                                     photos: [], prices_attributes: %i[id admin_id start_date end_date value])
-                                   
   end
 
   def set_product
     @product = Product.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     redirect_to root_path, notice: t('inactive_or_inexistent_product')
+  end
+
+  def set_cashback
+    return unless @product.cashback
+
+    @cashback = @product.cashback
+    @cashback_value = @product.current_price.rubies_value / @cashback.percentual
   end
 
   def set_new_price

--- a/app/views/cashbacks/index.html.erb
+++ b/app/views/cashbacks/index.html.erb
@@ -1,0 +1,23 @@
+<section class='pt-5 px-[2%] w-full'>
+  <div class="flex flex-col w-full items-center">
+
+    <div class="flex flex-col items-center w-full">
+      <h2>Cashbacks Registrados</h2>
+    </div>
+
+    <div class='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 m-auto'>
+      <% @cashbacks.each do |cashback| %>
+        <div class="cashback-wrapper max-w-[300px] shadow-lg rounded-md bg-gray-100 m-2">
+          <div id=<%= cashback.id %> class='cashback p-5 flex flex-col items-start space-y-2'>
+            <div class='self-center'>
+              <p class='text-xl font-semibold'><%= cashback.percentual %>%</p>
+            </div>
+            <p>Início: <%= I18n.l(cashback.start_date) %></p>
+            <p>Final: <%= I18n.l(cashback.end_date) %></p>
+            <p class='text-xs'>Cadastrado por <%= cashback.admin.name %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/cashbacks/index.html.erb
+++ b/app/views/cashbacks/index.html.erb
@@ -4,6 +4,7 @@
     <div class="flex flex-col items-center w-full">
       <h2>Cashbacks Registrados</h2>
     </div>
+    <%= link_to 'Cadastrar Cashback', new_cashback_path, class:'btn-primary ml-3'%>
 
     <% if @cashbacks.any? %>
       <div class='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 m-auto'>

--- a/app/views/cashbacks/index.html.erb
+++ b/app/views/cashbacks/index.html.erb
@@ -5,19 +5,26 @@
       <h2>Cashbacks Registrados</h2>
     </div>
 
-    <div class='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 m-auto'>
-      <% @cashbacks.each do |cashback| %>
-        <div class="cashback-wrapper max-w-[300px] shadow-lg rounded-md bg-gray-100 m-2">
-          <div id=<%= cashback.id %> class='cashback p-5 flex flex-col items-start space-y-2'>
-            <div class='self-center'>
-              <p class='text-xl font-semibold'><%= cashback.percentual %>%</p>
+    <% if @cashbacks.any? %>
+      <div class='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 m-auto'>
+        <% @cashbacks.each do |cashback| %>
+          <div class="cashback-wrapper max-w-[300px] shadow-lg rounded-md bg-gray-100 m-2">
+
+            <div id=<%= cashback.id %> class='cashback p-5 flex flex-col items-start space-y-2'>
+              <div class='self-center'>
+                <p class='text-xl font-semibold'><%= cashback.percentual %>%</p>
+              </div>
+
+              <p>Início: <%= I18n.l(cashback.start_date) %></p>
+              <p>Final: <%= I18n.l(cashback.end_date) %></p>
+              <p class='text-xs'>Cadastrado por <%= cashback.admin.name %></p>
             </div>
-            <p>Início: <%= I18n.l(cashback.start_date) %></p>
-            <p>Final: <%= I18n.l(cashback.end_date) %></p>
-            <p class='text-xs'>Cadastrado por <%= cashback.admin.name %></p>
           </div>
-        </div>
-      <% end %>
-    </div>
+        <% end %>
+      </div>
+
+    <% else %>
+        <div class='col-start-2 pt-5'>Não há cashbacks registrados</div>
+    <% end %>
   </div>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,7 @@
             <% if admin_signed_in? %>
               <div class= 'flex space-x-2'>
                 <li><%= link_to 'Promoções', promotions_path %></li>
+                <li><%= link_to 'Cashbacks', cashbacks_path %></li>
                 <li><%= link_to 'Categorias', categories_path %></li>
                 <li><%= link_to 'Cadastros Pendentes', pending_admins_path %></li>
               </div>
@@ -92,6 +93,7 @@
             <% if admin_signed_in? %>
               <div class= 'flex  flex-col space-y-2'>
                 <li><%= link_to 'Promoções', promotions_path %></li>
+                <li><%= link_to 'Cashbacks', cashbacks_path %></li>
                 <li><%= link_to 'Categorias', categories_path %></li>
                 <li><%= link_to 'Cadastros Pendentes', pending_admins_path %></li>
               </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,13 +1,12 @@
 <section class='pt-5 px-[2%] w-full'>
   <div class='flex w-full flex-wrap'>
     <%= form_with url: search_products_path, method: :get, html: {class: 'flex items-center'} do |form| %>
-      <%= form.text_field :query, placeholder: "Pesquisar", id: "Buscar", class:'rounded-lg h-8 max-w-[200px]'%>
+      <%= form.text_field :query, placeholder: "Pesquisar", id: "Buscar", class:'rounded-lg h-8 max-w-[200px]' %>
       <%= form.submit "Buscar", class:'btn-second ml-2 mr-3' %>
     <% end %>
     <% if admin_signed_in? %>
       <div>
         <%= link_to 'Cadastrar Produto', new_product_path, class:'btn-second ml-3' %>
-        <%= link_to 'Cadastrar Cashback', new_cashback_path, class:'btn-second ml-3'%>
       </div>
     <% end %>
   </div>
@@ -26,9 +25,9 @@
       <% if @products.any? %>
         <% @products.each do |product| %>
         <div id=<%= product.id %> class='m-2 max-w-[250px] h-[280px] shadow-lg rounded-md overflow-hidden'>
-          <div class=''>            
-            <%= link_to(image_tag(product.photos.last), product_path(product)) if product.photos.attached? %>                
-            <div class='p-2 '>
+          <div class=''>
+            <%= link_to(image_tag(product.photos.last), product_path(product)) if product.photos.attached? %>
+            <div class='p-2'>
               <h3 class='font-semibold'>Nome: <%= link_to product.name, product_path(product) %> </h3>
               <p>Marca: <%= product.brand %></p>
               <p><%= Product.human_attribute_name("status.#{product.status}") if admin_signed_in? %></p>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -16,7 +16,7 @@
             <%= image_tag('rubi', class: "img-responsive w-[20px] h-[20px]")%>
           </div>
           <% unless @cashback.nil? %>
-            <p class='text-xs text-green-500'>Cashback de <%= "#{@cashback.percentual}% - #{number_to_currency(@cashback_value, unit: '$')} " %>
+            <p class='text-xs text-green-500'>Cashback de <%= "#{@cashback.percentual}% | #{number_to_currency(@cashback_value, unit: '$')} " %>
             <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px] inline-block") %></p>
           <% end %>
           <div class='flex space-x-1 items-center'>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -15,6 +15,10 @@
             <p class='text-2xl font-semibold'>$<%= number_with_precision(@product.current_price.rubies_value, precision: 2) %> </p>
             <%= image_tag('rubi', class: "img-responsive w-[20px] h-[20px]")%>
           </div>
+          <% unless @cashback.nil? %>
+            <p class='text-xs text-red-500'>Cashback de <%= "#{@cashback.percentual}% - #{number_to_currency(@cashback_value, unit: '$')} " %>
+            <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px] inline-block") %></p>
+          <% end %>
           <div class='flex space-x-1 items-center'>
             <p class='text-lg font-semibold'>Frete: $<%= number_with_precision(@product.rubies_shipping_price, precision: 2) %></p>
             <%= image_tag('rubi', class: "img-responsive w-[20px] h-[20px]") %>
@@ -30,9 +34,7 @@
       </div>
     </div>
     <h3 class="text-xl mt-6 mb-2 font-semibold">Informações do Produto</h3>
-    <% unless @product.cashback.nil? %> 
-      <p>Cashback: <%= @product.cashback.extended_description %></p>
-    <% end %>
+    
     <p>Descrição: <%= @product.description %></p>
     <p>SKU: <%= @product.sku %></p>
     <p>Marca: <%= @product.brand %></p>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -16,7 +16,7 @@
             <%= image_tag('rubi', class: "img-responsive w-[20px] h-[20px]")%>
           </div>
           <% unless @cashback.nil? %>
-            <p class='text-xs text-red-500'>Cashback de <%= "#{@cashback.percentual}% - #{number_to_currency(@cashback_value, unit: '$')} " %>
+            <p class='text-xs text-green-500'>Cashback de <%= "#{@cashback.percentual}% - #{number_to_currency(@cashback_value, unit: '$')} " %>
             <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px] inline-block") %></p>
           <% end %>
           <div class='flex space-x-1 items-center'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     end
   end
   resources :prices, only: :create
-  resources :cashbacks, only: %i[new create]
+  resources :cashbacks, only: %i[index new create]
 
   get 'shopping_cart', to: 'shopping_cart#index'
   resources :purchases, only: %i[index create]

--- a/spec/system/admin/cashback/admin_registers_cashback_spec.rb
+++ b/spec/system/admin/cashback/admin_registers_cashback_spec.rb
@@ -5,7 +5,7 @@ describe 'Administrador cria cashback' do
     admin = create :admin
 
     login_as admin, scope: :admin
-    visit root_path
+    visit cashbacks_path
     click_on 'Cadastrar Cashback'
     fill_in 'Data Inicial', with: 1.day.from_now
     fill_in 'Data Final', with: 1.month.from_now

--- a/spec/system/admin/cashback/admin_views_cashbacks_spec.rb
+++ b/spec/system/admin/cashback/admin_views_cashbacks_spec.rb
@@ -27,4 +27,13 @@ describe 'Administrador visita a tela de cashbacks registrados' do
       expect(page).to have_content 'Cadastrado por José'
     end
   end
+
+  it 'e não há cashbacks registrados' do
+    admin = create :admin
+
+    login_as admin, scope: :admin
+    visit cashbacks_path
+
+    expect(page).to have_content 'Não há cashbacks registrados'
+  end
 end

--- a/spec/system/admin/cashback/admin_views_cashbacks_spec.rb
+++ b/spec/system/admin/cashback/admin_views_cashbacks_spec.rb
@@ -16,14 +16,14 @@ describe 'Administrador visita a tela de cashbacks registrados' do
     expect(page).to have_content 'Cashbacks Registrados'
     within("##{cashback1.id}") do
       expect(page).to have_content '15%'
-      expect(page).to have_content "Início: #{Time.zone.today}"
-      expect(page).to have_content "Final: #{10.days.from_now.to_date}"
+      expect(page).to have_content "Início: #{I18n.l(Time.zone.today)}"
+      expect(page).to have_content "Final: #{I18n.l(10.days.from_now.to_date)}"
       expect(page).to have_content 'Cadastrado por José'
     end
     within("##{cashback2.id}") do
       expect(page).to have_content '5%'
-      expect(page).to have_content "Início: #{5.days.from_now.to_date}"
-      expect(page).to have_content "Final: #{15.days.from_now.to_date}"
+      expect(page).to have_content "Início: #{I18n.l(5.days.from_now.to_date)}"
+      expect(page).to have_content "Final: #{I18n.l(15.days.from_now.to_date)}"
       expect(page).to have_content 'Cadastrado por José'
     end
   end

--- a/spec/system/admin/cashback/admin_views_cashbacks_spec.rb
+++ b/spec/system/admin/cashback/admin_views_cashbacks_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'Administrador visita a tela de cashbacks registrados' do
+  it 'com sucesso' do
+    admin = create :admin, name: 'José'
+    cashback1 = create :cashback, admin: admin, start_date: Time.zone.today,
+                                  end_date: 10.days.from_now, percentual: 15
+    cashback2 = create :cashback, admin: admin, start_date: 5.days.from_now,
+                                  end_date: 15.days.from_now, percentual: 5
+
+    login_as admin, scope: :admin
+    visit root_path
+    find('#menu-desktop').click_on 'Cashbacks'
+
+    expect(page).to have_current_path cashbacks_path
+    expect(page).to have_content 'Cashbacks Registrados'
+    within("##{cashback1.id}") do
+      expect(page).to have_content '15%'
+      expect(page).to have_content "Início: #{Time.zone.today}"
+      expect(page).to have_content "Final: #{10.days.from_now.to_date}"
+      expect(page).to have_content 'Cadastrado por José'
+    end
+    within("##{cashback2.id}") do
+      expect(page).to have_content '5%'
+      expect(page).to have_content "Início: #{5.days.from_now.to_date}"
+      expect(page).to have_content "Final: #{15.days.from_now.to_date}"
+      expect(page).to have_content 'Cadastrado por José'
+    end
+  end
+end

--- a/spec/system/visitor/product/visitor_views_product_details_spec.rb
+++ b/spec/system/visitor/product/visitor_views_product_details_spec.rb
@@ -28,7 +28,7 @@ describe 'Visitante vê detalhes de um produto' do
     expect(page).to have_content('Peso: 12,00 kg')
     expect(page).to have_content('Frete: $5,00')
     expect(page).to have_content('$10,00')
-    expect(page).to have_content('Cashback de 10% - $ 1,00')
+    expect(page).to have_content('Cashback de 10% | $ 1,00')
     expect(page).to have_content('Frágil - Sim')
     expect(page).not_to have_content('Preço do Frete: R$ 10,00')
     expect(page).not_to have_content('Preço: R$ 20,00')

--- a/spec/system/visitor/product/visitor_views_product_details_spec.rb
+++ b/spec/system/visitor/product/visitor_views_product_details_spec.rb
@@ -4,9 +4,11 @@ describe 'Visitante vê detalhes de um produto' do
   it 'a partir da tela de produtos' do
     create :exchange_rate, value: 2.0
     category = create(:category, name: 'Eletrônicos')
+    cashback = create(:cashback, percentual: 10, start_date: Time.zone.today, end_date: 7.days.from_now)
     product = create(:product, name: 'Monitor 8k', brand: 'LG', description: 'Monitor de alta qualidade',
                                sku: 'MON8K-64792', height: 50, width: 100, depth: 12, weight: 12,
-                               shipping_price: 10.00, fragile: true, status: :active, category: category)
+                               shipping_price: 10.00, fragile: true, status: :active, category: category,
+                               cashback: cashback)
     product.photos.attach(io: File.open(Rails.root.join('spec/support/files/placeholder-image-1.png')),
                           filename: 'placeholder-image-1.png', content_type: 'image/png')
     create(:price, product: product, start_date: Time.zone.today, end_date: 7.days.from_now, value: 20.00)
@@ -25,8 +27,9 @@ describe 'Visitante vê detalhes de um produto' do
     expect(page).to have_content('Dimensões: 100,00 x 50,00 x 12,00')
     expect(page).to have_content('Peso: 12,00 kg')
     expect(page).to have_content('Frete: $5,00')
-    expect(page).to have_content('Frágil - Sim')
     expect(page).to have_content('$10,00')
+    expect(page).to have_content('Cashback de 10% - $ 1,00')
+    expect(page).to have_content('Frágil - Sim')
     expect(page).not_to have_content('Preço do Frete: R$ 10,00')
     expect(page).not_to have_content('Preço: R$ 20,00')
     expect(page).not_to have_content('Ativo')

--- a/spec/system/visitor/visitor_visits_admin_routes_spec.rb
+++ b/spec/system/visitor/visitor_visits_admin_routes_spec.rb
@@ -31,6 +31,13 @@ describe 'Visitante não autenticado tenta acessar' do
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
+  it 'a tela de listagem de cashbacks' do
+    visit cashbacks_path
+
+    expect(page).to have_current_path new_admin_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
+
   it 'a tela de cadastro de novo cashback' do
     visit new_cashback_path
 


### PR DESCRIPTION
## Resolve #106.

Esta PR cria uma tela que lista todos os cashbacks cadastrados no sistema, acessível apenas para administradores. Nela, podemos visualizar:

- Percentual de cashback;
- Data de início e fim do cashback;
- Administrador que o cadastrou.