### PR TITLE
Adiciona valor de cashback à compra

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -22,6 +22,6 @@ class PurchasesController < ApplicationController
   private
 
   def purchase_params
-    params.permit(:client_id, :value)
+    params.permit(:client_id, :value, :cashback_value)
   end
 end

--- a/app/controllers/shopping_cart_controller.rb
+++ b/app/controllers/shopping_cart_controller.rb
@@ -7,5 +7,6 @@ class ShoppingCartController < ApplicationController
     @total_shipping = current_client.purchase_shipping_value
     @total_products = current_client.purchase_value
     @total = @total_shipping + @total_products
+    @cashback = current_client.purchase_cashback_value
   end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -18,11 +18,15 @@ class Client < ApplicationRecord
   end
 
   def purchase_value
-    product_items.sum(&:define_product_total_price)
+    product_items.sum(&:total_price)
   end
 
   def purchase_shipping_value
-    product_items.sum(&:define_product_shipping_price)
+    product_items.sum(&:total_shipping_price)
+  end
+
+  def purchase_cashback_value
+    product_items.sum(&:cashback_value)
   end
 
   private

--- a/app/models/product_item.rb
+++ b/app/models/product_item.rb
@@ -3,11 +3,17 @@ class ProductItem < ApplicationRecord
   belongs_to :client, optional: true
   belongs_to :purchase, optional: true
 
-  def define_product_total_price
+  def total_price
     product.current_price.rubies_value * quantity
   end
 
-  def define_product_shipping_price
+  def total_shipping_price
     product.rubies_shipping_price * quantity
+  end
+
+  def cashback_value
+    return 0.0 unless product.cashback
+
+    total_price / product.cashback.percentual
   end
 end

--- a/app/views/shopping_cart/index.html.erb
+++ b/app/views/shopping_cart/index.html.erb
@@ -71,15 +71,17 @@
               <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
             </div>
 
-            <div class='flex items-center space-x-1'>
-              <p>Cashback Total: <span class='text-lg font-semibold text-green-500'>$<%= number_with_precision(@cashback, precision: 2) %></span> </p>
-              <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
-            </div>
+            <% if @cashback > 0 %>
+              <div class='flex items-center space-x-1'>
+                <p>Cashback Total: <span class='text-lg font-semibold text-green-500'>$<%= number_with_precision(@cashback, precision: 2) %></span> </p>
+                <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
+              </div>
+            <% end %>
 
-            <div class='btn-primary  self-start'>
-              <%= button_to 'Confirmar Compra', purchases_path(client_id: current_client.id, value: @total,
-                                                               cashback_value: @cashback), method: :post, class:'w-[200px]' %>
-            </div>
+              <div class='btn-primary  self-start'>
+                <%= button_to 'Confirmar Compra', purchases_path(client_id: current_client.id, value: @total,
+                                                                cashback_value: @cashback), method: :post, class:'w-[200px]' %>
+              </div>
           </div>
         </div>
       </div>

--- a/app/views/shopping_cart/index.html.erb
+++ b/app/views/shopping_cart/index.html.erb
@@ -55,18 +55,27 @@
         <div class='bg-slate-50 py-4 px-6 shadow-md rounded-md w-full flex flex-col items-center'>
           <div class='space-y-3'>
             <h2>Resumo</h2>
+
             <div class='flex items-center space-x-1'>
               <p>Total produtos: <span class='text-lg font-semibold'>$<%= number_with_precision(@total_products, precision: 2) %></span> </p>
               <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
             </div>
-            <div  class='flex items-center space-x-1'>
+
+            <div class='flex items-center space-x-1'>
               <p>Total frete: <span class='text-lg font-semibold'>$<%= number_with_precision(@total_shipping, precision: 2)%></span> </p>
               <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
             </div>
-            <div  class='flex items-center space-x-1'>
+
+            <div class='flex items-center space-x-1'>
               <p>Total: <span class='text-2xl font-semibold'>$<%= number_with_precision(@total, precision: 2) %></span> </p>
               <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
             </div>
+
+            <div class='flex items-center space-x-1'>
+              <p>Cashback Total: <span class='text-lg font-semibold text-green-500'>$<%= number_with_precision(@cashback, precision: 2) %></span> </p>
+              <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
+            </div>
+
             <div class='btn-primary  self-start'>
               <%= button_to 'Confirmar Compra', purchases_path(client_id: current_client.id, value: @total,
                                                                cashback_value: @cashback), method: :post, class:'w-[200px]' %>

--- a/app/views/shopping_cart/index.html.erb
+++ b/app/views/shopping_cart/index.html.erb
@@ -1,6 +1,6 @@
 <section class='p-[2%] w-full max-w-5xl flex mt-5 m-auto bg-gray-100'>
   <div class='px-4 pb-10 w-full flex flex-col'>
-    <% unless @product_items.empty? %>      
+    <% unless @product_items.empty? %>
       <div class="w-full flex flex-col">
         <h2><%= t('my_cart') %></h2>
         <h4 class='text-xl font-semibold pb-1'>Produtos</h4>
@@ -21,11 +21,11 @@
                   <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
                 </div>
                 <div  class='flex items-center space-x-1'>
-                  <p>Subtotal: $<%= number_with_precision(item.define_product_total_price, precision: 2) %></p>
+                  <p>Subtotal: $<%= number_with_precision(item.total_price, precision: 2) %></p>
                   <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
                 </div>
                 <div  class='flex items-center space-x-1'>
-                  <p>Frete: $<%= number_with_precision(item.define_product_shipping_price, precision: 2) %></p>
+                  <p>Frete: $<%= number_with_precision(item.total_shipping_price, precision: 2) %></p>
                   <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
                 </div>
               </div>
@@ -43,15 +43,15 @@
                         2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
                       </path>
                     </svg>
-                  <%end%>  
-                </div>                    
+                  <%end%>
+                </div>
               </div>
             </div>
           </div>
         <% end %>
       </div>
 
-      <div class='w-full pt-12 '>        
+      <div class='w-full pt-12 '>
         <div class='bg-slate-50 py-4 px-6 shadow-md rounded-md w-full flex flex-col items-center'>
           <div class='space-y-3'>
             <h2>Resumo</h2>
@@ -68,7 +68,8 @@
               <%= image_tag('rubi', class: "img-responsive w-[16px] h-[16px]")%>
             </div>
             <div class='btn-primary  self-start'>
-              <%= button_to 'Confirmar Compra', purchases_path(client_id: current_client.id, value: @total), method: :post, class:'w-[200px]' %> 
+              <%= button_to 'Confirmar Compra', purchases_path(client_id: current_client.id, value: @total,
+                                                               cashback_value: @cashback), method: :post, class:'w-[200px]' %>
             </div>
           </div>
         </div>

--- a/spec/system/client/product_item/client_views_cart_spec.rb
+++ b/spec/system/client/product_item/client_views_cart_spec.rb
@@ -4,7 +4,8 @@ describe 'Cliente vê carrinho' do
   it 'e vê produtos adicionados ao carrinho' do
     create :exchange_rate, value: 2.00
     client = create :client
-    first_product = create :product, name: 'Mouse', shipping_price: 10.00
+    cashback = create :cashback, percentual: 10
+    first_product = create :product, name: 'Mouse', shipping_price: 10.00, cashback: cashback
     create :price, product: first_product, value: 10.00
     second_product = create :product, category: first_product.category, name: 'Monitor 8k',
                                       shipping_price: 20.00
@@ -36,6 +37,7 @@ describe 'Cliente vê carrinho' do
     expect(page).to have_content 'Total frete: $25,00'
     expect(page).to have_content 'Total produtos: $25,00'
     expect(page).to have_content 'Total: $50,00'
+    expect(page).to have_content 'Cashback Total: $0,50'
   end
 
   it 'e não há produtos duplicados' do

--- a/spec/system/client/product_item/client_views_cart_spec.rb
+++ b/spec/system/client/product_item/client_views_cart_spec.rb
@@ -85,4 +85,17 @@ describe 'Cliente vê carrinho' do
     expect(page).to have_current_path product_path(second_product)
     expect(page).to have_content 'Mouse'
   end
+
+  it 'e a compra não possui cashback' do
+    create :exchange_rate, value: 2.00
+    client = create :client
+    product = create :product
+    create :price, product: product
+    create :product_item, product: product, client: client
+
+    login_as client, scope: :client
+    visit shopping_cart_path
+
+    expect(page).not_to have_content 'Cashback Total'
+  end
 end

--- a/spec/system/client/purchase/client_confirms_purchase_spec.rb
+++ b/spec/system/client/purchase/client_confirms_purchase_spec.rb
@@ -2,16 +2,17 @@ require 'rails_helper'
 
 describe 'Cliente confirma compra' do
   it 'com sucesso' do
-    create :exchange_rate, value: 2.0
     client = create :client, code: '510.309.910-14'
-    first_product = create :product, shipping_price: 10.00
+    create :exchange_rate, value: 2.0
+    cashback = create :cashback, percentual: 10
+    first_product = create :product, shipping_price: 10.00, cashback: cashback
     create :price, product: first_product, value: 20.00
     second_product = create :product, category: first_product.category, shipping_price: 20.00
     create :price, product: second_product, value: 10.00
     first_item = create :product_item, client: client, product: first_product, quantity: 1
     second_item = create :product_item, client: client, product: second_product, quantity: 1
     purchase_data_sent = { transaction: { order: 1, registered_number: '510.309.910-14',
-                                          value: 3000, cashback: 0 } }.to_json
+                                          value: 3000, cashback: 100 } }.to_json
     purchase_status_data = { transaction: { order: 1, registered_number: '510.309.910-14',
                                             status: 'accepted', message: nil } }.to_json
     purchase_response = instance_double Faraday::Response, status: :created, body: purchase_status_data
@@ -25,6 +26,7 @@ describe 'Cliente confirma compra' do
 
     expect(page).to have_current_path root_path
     expect(Purchase.count).to eq 1
+    expect(Purchase.last.cashback_value).to eq 1.0
     expect(Purchase.last).to be_approved
     expect(Purchase.last.product_items).to eq [first_item, second_item]
     expect(client.product_items).to be_empty


### PR DESCRIPTION
## Atende #107.

Com esta PR, um cliente que confirmar uma compra envia a Pagamentos, junto do valor total da compra, o valor total do _cashback_ desta, se houver.

Além disso, o valor do _cashback_ total da compra, se houver, é exibido no carrinho do cliente.

Carrinho de compras:
<img width="584" alt="Captura de tela 2022-06-30 170104" src="https://user-images.githubusercontent.com/10002979/176767973-9414cfd5-6c32-4e37-87d2-48572f9a2a67.png">